### PR TITLE
Exclude assets by RegExp

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,39 @@ The Alt Text Generator for CraftCMS supports the following image formats:
 - **AVIF**
 - **SVG**
 
+## Exclude Specific Images
+
+You can prevent certain assets from being processed in two ways:
+
+- Disable entire Asset Volumes in plugin settings (recommended)
+- Use a regex rule in your `.env` to exclude files by path
+
+### Method 1: Disable Asset Volumes (Recommended)
+
+1. In Craft, go to `AltTextLab → Settings`.
+2. Find the "Disable volumes" option.
+3. Select one or more volumes to exclude. Assets stored in these volumes will be skipped during both automatic and bulk alt text generation.
+
+This method is simple, safe, and easy to maintain.
+
+### Method 2: Advanced exclusion via regex (Environment variable)
+
+For finer control, you can exclude files by matching their full file system path with a regular expression. Define the following environment variable in your `.env` file:
+
+```bash
+# Examples (pick one and adjust to your needs)
+ALT_TEXT_LAB_EXCLUDE_REGEX=~/(thumbnails|icons)/~i
+# Or exclude anything in /uploads/tmp/
+# ALT_TEXT_LAB_EXCLUDE_REGEX=~/uploads/tmp/~
+# Or exclude all SVGs inside "branding" folder
+# ALT_TEXT_LAB_EXCLUDE_REGEX=~branding/.+\.svg$~i
+```
+
+Notes:
+- The pattern is applied against the asset's full local path, which includes the volume file system path, optional `subpath`, and the asset path.
+- You may provide a PCRE pattern with delimiters (e.g., `~/pattern/~i`). If you omit delimiters, the plugin will attempt to wrap your pattern automatically.
+- Regex-based exclusions apply to both automatic generation and bulk operations.
+
 ## Troubleshooting
 
 - The plugin includes a **AltTextLab → Logs** page where you can view any errors related to alt text generation.

--- a/src/services/AltTextLabAssetsService.php
+++ b/src/services/AltTextLabAssetsService.php
@@ -168,7 +168,8 @@ class AltTextLabAssetsService
                 return;
             }
 
-            if ($this->utilityService->isPathExcludedByRegex($asset)){
+            $regexExcludePathPattern = $this->utilityService->getExcludeRegexEnv();
+            if ($regexExcludePathPattern && $this->utilityService->isPathExcludedByRegex($asset, $regexExcludePathPattern)){
                 return;
             }
 

--- a/src/services/AltTextLabAssetsService.php
+++ b/src/services/AltTextLabAssetsService.php
@@ -168,6 +168,10 @@ class AltTextLabAssetsService
                 return;
             }
 
+            if ($this->utilityService->isPathExcludedByRegex($asset)){
+                return;
+            }
+
             if (!$this->utilityService->checkAssetIsValid($asset, $bulkGenerationId)) {
                 return;
             }
@@ -220,15 +224,7 @@ class AltTextLabAssetsService
 
             $body = ['imageUrl' => $imageUrl];
         } else {
-            $fsPath = Craft::getAlias($asset->getVolume()->fs->path ?? '');
-            $subpath = Craft::parseEnv($asset->getVolume()->subpath ?? '');
-
-            $fsPath = rtrim($fsPath, DIRECTORY_SEPARATOR);
-            $subpath = trim($subpath, DIRECTORY_SEPARATOR);
-
-            $rootPath = $subpath ? ($fsPath . DIRECTORY_SEPARATOR . $subpath) : $fsPath;
-
-            $filePath = rtrim($rootPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . ltrim($asset->getPath(), DIRECTORY_SEPARATOR);
+            $filePath = $this->utilityService->getFilePath($asset);
 
             if (!file_exists($filePath)) {
                 $this->logService->log($asset->id, $bulkGenerationId, "File doesn't exist: " . $filePath);

--- a/src/services/CraftAssetsService.php
+++ b/src/services/CraftAssetsService.php
@@ -9,6 +9,13 @@ use craft\elements\Asset as AssetElement;
 class CraftAssetsService
 {
 
+    private $utilityService;
+
+    public function __construct()
+    {
+        $this->utilityService = new UtilityService();
+    }
+
     public function getCountAssets(array $assetIds = []): int
     {
         $settings = AltTextLab::getInstance()->getSettings();
@@ -28,9 +35,18 @@ class CraftAssetsService
         }
 
         if (empty($altFieldHandle) || $altFieldHandle === 'alt') {
-            $count = $query->count();
+            foreach ($query->each() as $asset) {
+                if ($this->utilityService->isPathExcludedByRegex($asset)) {
+                    continue;
+                }
+                $count++;
+            }
         } else {
             foreach ($query->each() as $asset) {
+                if ($this->utilityService->isPathExcludedByRegex($asset)) {
+                    continue;
+                }
+
                 $fieldLayout = $asset->getFieldLayout();
 
                 if (!$fieldLayout || !$fieldLayout->getFieldByHandle($altFieldHandle)) {
@@ -65,9 +81,19 @@ class CraftAssetsService
 
         if (empty($altFieldHandle) || $altFieldHandle === 'alt') {
             $assetsQuery->hasAlt($hasAltText);
-            $count = $assetsQuery->count();
+
+            foreach ($assetsQuery->each() as $asset) {
+                if ($this->utilityService->isPathExcludedByRegex($asset)) {
+                    continue;
+                }
+                $count++;
+            }
         } else {
             foreach ($assetsQuery->each() as $asset) {
+                if ($this->utilityService->isPathExcludedByRegex($asset)) {
+                    continue;
+                }
+
                 $fieldLayout = $asset->getFieldLayout();
 
                 if (!$fieldLayout || !$fieldLayout->getFieldByHandle($altFieldHandle)) {
@@ -110,9 +136,18 @@ class CraftAssetsService
             if (!$hasAltText){
                 $query->hasAlt($hasAltText);
             }
-            $resultAssets = $query->all();
+            foreach ($query->each() as $asset) {
+                if ($this->utilityService->isPathExcludedByRegex($asset)) {
+                    continue;
+                }
+                $resultAssets[] = $asset;
+            }
         } else {
             foreach ($query->each() as $asset) {
+                if ($this->utilityService->isPathExcludedByRegex($asset)) {
+                    continue;
+                }
+
                 $fieldLayout = $asset->getFieldLayout();
 
                 if (!$fieldLayout || !$fieldLayout->getFieldByHandle($altFieldHandle)) {

--- a/src/services/CraftAssetsService.php
+++ b/src/services/CraftAssetsService.php
@@ -34,16 +34,22 @@ class CraftAssetsService
             $query->id($assetIds);
         }
 
+        $regexExcludePathPattern = $this->utilityService->getExcludeRegexEnv();
+
         if (empty($altFieldHandle) || $altFieldHandle === 'alt') {
-            foreach ($query->each() as $asset) {
-                if ($this->utilityService->isPathExcludedByRegex($asset)) {
-                    continue;
+            if ($regexExcludePathPattern) {
+                foreach ($query->each() as $asset) {
+                    if ($this->utilityService->isPathExcludedByRegex($asset, $regexExcludePathPattern)) {
+                        continue;
+                    }
+                    $count++;
                 }
-                $count++;
+            } else {
+                $count = $query->count();
             }
         } else {
             foreach ($query->each() as $asset) {
-                if ($this->utilityService->isPathExcludedByRegex($asset)) {
+                if ($regexExcludePathPattern && $this->utilityService->isPathExcludedByRegex($asset, $regexExcludePathPattern)) {
                     continue;
                 }
 
@@ -79,18 +85,23 @@ class CraftAssetsService
             $assetsQuery->id($assetIds);
         }
 
+        $regexExcludePathPattern = $this->utilityService->getExcludeRegexEnv();
+
         if (empty($altFieldHandle) || $altFieldHandle === 'alt') {
             $assetsQuery->hasAlt($hasAltText);
-
-            foreach ($assetsQuery->each() as $asset) {
-                if ($this->utilityService->isPathExcludedByRegex($asset)) {
-                    continue;
+            if ($regexExcludePathPattern) {
+                foreach ($assetsQuery->each() as $asset) {
+                    if ($this->utilityService->isPathExcludedByRegex($asset, $regexExcludePathPattern)) {
+                        continue;
+                    }
+                    $count++;
                 }
-                $count++;
+            } else {
+                $count = $assetsQuery->count();
             }
         } else {
             foreach ($assetsQuery->each() as $asset) {
-                if ($this->utilityService->isPathExcludedByRegex($asset)) {
+                if ($regexExcludePathPattern && $this->utilityService->isPathExcludedByRegex($asset, $regexExcludePathPattern)) {
                     continue;
                 }
 
@@ -132,19 +143,26 @@ class CraftAssetsService
             $query->id($assetIds);
         }
 
+        $regexExcludePathPattern = $this->utilityService->getExcludeRegexEnv();
+
         if (empty($altFieldHandle) || $altFieldHandle === 'alt') {
             if (!$hasAltText){
                 $query->hasAlt($hasAltText);
             }
-            foreach ($query->each() as $asset) {
-                if ($this->utilityService->isPathExcludedByRegex($asset)) {
-                    continue;
+
+            if ($regexExcludePathPattern) {
+                foreach ($query->each() as $asset) {
+                    if ($this->utilityService->isPathExcludedByRegex($asset, $regexExcludePathPattern)) {
+                        continue;
+                    }
+                    $resultAssets[] = $asset;
                 }
-                $resultAssets[] = $asset;
+            } else {
+                $resultAssets = $query->all();
             }
         } else {
             foreach ($query->each() as $asset) {
-                if ($this->utilityService->isPathExcludedByRegex($asset)) {
+                if ($regexExcludePathPattern && $this->utilityService->isPathExcludedByRegex($asset, $regexExcludePathPattern)) {
                     continue;
                 }
 

--- a/src/services/UtilityService.php
+++ b/src/services/UtilityService.php
@@ -47,13 +47,11 @@ class UtilityService
         return true;
     }
 
-    public function isPathExcludedByRegex($asset): bool
+    public function isPathExcludedByRegex($asset, $pattern): bool
     {
         if (!$asset) {
             return false;
         }
-
-        $pattern = App::parseEnv(self::ENV_EXCLUDE_REGEX);
 
         if (!$pattern || trim($pattern) === '') {
             return false;
@@ -88,6 +86,11 @@ class UtilityService
 
         $filePath = rtrim($rootPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . ltrim($asset->getPath(), DIRECTORY_SEPARATOR);
         return $filePath;
+    }
+
+    public function getExcludeRegexEnv()
+    {
+        return App::parseEnv(self::ENV_EXCLUDE_REGEX);
     }
 
     public function logMessage(string $message, $bulkGenerationId, $assetId): void

--- a/src/services/UtilityService.php
+++ b/src/services/UtilityService.php
@@ -2,11 +2,13 @@
 namespace alttextlab\AltTextLab\services;
 
 use Craft;
+use craft\helpers\App;
 
 class UtilityService
 {
 
     private $logService;
+    private const ENV_EXCLUDE_REGEX = '$ALT_TEXT_LAB_EXCLUDE_REGEX';
 
     public function __construct()
     {
@@ -43,6 +45,49 @@ class UtilityService
         }
 
         return true;
+    }
+
+    public function isPathExcludedByRegex($asset): bool
+    {
+        if (!$asset) {
+            return false;
+        }
+
+        $pattern = App::parseEnv(self::ENV_EXCLUDE_REGEX);
+
+        if (!$pattern || trim($pattern) === '') {
+            return false;
+        }
+
+        $path = $this->getFilePath($asset);
+
+        if (!$path) {
+            return false;
+        }
+
+        $pattern = trim($pattern);
+
+        $result = @preg_match($pattern, $path);
+
+        if ($result === false) {
+            $result = @preg_match('~' . $pattern . '~', $path);
+        }
+
+        return $result === 1;
+    }
+
+    public function getFilePath($asset)
+    {
+        $fsPath = Craft::getAlias($asset->getVolume()->fs->path ?? '');
+        $subpath = Craft::parseEnv($asset->getVolume()->subpath ?? '');
+
+        $fsPath = rtrim($fsPath, DIRECTORY_SEPARATOR);
+        $subpath = trim($subpath, DIRECTORY_SEPARATOR);
+
+        $rootPath = $subpath ? ($fsPath . DIRECTORY_SEPARATOR . $subpath) : $fsPath;
+
+        $filePath = rtrim($rootPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . ltrim($asset->getPath(), DIRECTORY_SEPARATOR);
+        return $filePath;
     }
 
     public function logMessage(string $message, $bulkGenerationId, $assetId): void


### PR DESCRIPTION
This pull request introduces support for excluding assets based on a configurable regular expression pattern, allowing users to filter out assets by their file paths.
Resolves https://github.com/alttextlab/alt-text-craftcms/issues/6